### PR TITLE
Adding offset and inversion handling

### DIFF
--- a/components/tft/tft.c
+++ b/components/tft/tft.c
@@ -79,10 +79,10 @@ uint32_t tft_tp_calx = 7472920;
 uint32_t tft_tp_caly = 122224794;
 
 dispWin_t tft_dispWin = {
-  .x1 = 0,
-  .y1 = 0,
-  .x2 = DEFAULT_TFT_DISPLAY_WIDTH,
-  .y2 = DEFAULT_TFT_DISPLAY_HEIGHT,
+  .x1 = TFT_STATIC_WIDTH_OFFSET,
+  .y1 = TFT_STATIC_HEIGHT_OFFSET,
+  .x2 = DEFAULT_TFT_DISPLAY_WIDTH + TFT_STATIC_WIDTH_OFFSET,
+  .y2 = DEFAULT_TFT_DISPLAY_HEIGHT + TFT_STATIC_HEIGHT_OFFSET,
 };
 
 Font tft_cfont = {
@@ -296,7 +296,7 @@ void TFT_fillRect(int16_t x, int16_t y, int16_t w, int16_t h, color_t color) {
 
 //==================================
 void TFT_fillScreen(color_t color) {
-	TFT_pushColorRep(0, 0, tft_width-1, tft_height-1, color, (uint32_t)(tft_height*tft_width));
+	TFT_pushColorRep(TFT_STATIC_X_OFFSET, TFT_STATIC_Y_OFFSET, tft_width + TFT_STATIC_X_OFFSET -1, tft_height + TFT_STATIC_Y_OFFSET -1, color, (uint32_t)(tft_height*tft_width));
 }
 
 //==================================
@@ -2056,10 +2056,10 @@ void TFT_setRotation(uint8_t rot) {
         _tft_setRotation(rot);
 	}
 
-	tft_dispWin.x1 = 0;
-	tft_dispWin.y1 = 0;
-	tft_dispWin.x2 = tft_width-1;
-	tft_dispWin.y2 = tft_height-1;
+	tft_dispWin.x1 = TFT_STATIC_X_OFFSET;
+	tft_dispWin.y1 = TFT_STATIC_Y_OFFSET;
+	tft_dispWin.x2 = tft_width + TFT_STATIC_X_OFFSET -1;
+	tft_dispWin.y2 = tft_height + TFT_STATIC_Y_OFFSET -1;
 
 	TFT_fillScreen(tft_bg);
 }
@@ -2157,13 +2157,13 @@ color_t HSBtoRGB(float _hue, float _sat, float _brightness) {
 //=====================================================================
 void TFT_setclipwin(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2)
 {
-	tft_dispWin.x1 = x1;
-	tft_dispWin.y1 = y1;
-	tft_dispWin.x2 = x2;
-	tft_dispWin.y2 = y2;
+	tft_dispWin.x1 = x1 + TFT_STATIC_X_OFFSET;
+	tft_dispWin.y1 = y1 + TFT_STATIC_Y_OFFSET;
+	tft_dispWin.x2 = x2 + TFT_STATIC_X_OFFSET;
+	tft_dispWin.y2 = y2 + TFT_STATIC_Y_OFFSET;
 
-	if (tft_dispWin.x2 >= tft_width) tft_dispWin.x2 = tft_width-1;
-	if (tft_dispWin.y2 >= tft_height) tft_dispWin.y2 = tft_height-1;
+	if (tft_dispWin.x2 >= tft_width + TFT_STATIC_X_OFFSET) tft_dispWin.x2 = tft_width + TFT_STATIC_X_OFFSET -1;
+	if (tft_dispWin.y2 >= tft_height + TFT_STATIC_Y_OFFSET) tft_dispWin.y2 = tft_height + TFT_STATIC_Y_OFFSET -1;
 	if (tft_dispWin.x1 > tft_dispWin.x2) tft_dispWin.x1 = tft_dispWin.x2;
 	if (tft_dispWin.y1 > tft_dispWin.y2) tft_dispWin.y1 = tft_dispWin.y2;
 }
@@ -2171,10 +2171,10 @@ void TFT_setclipwin(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2)
 //=====================
 void TFT_resetclipwin()
 {
-	tft_dispWin.x2 = tft_width-1;
-	tft_dispWin.y2 = tft_height-1;
-	tft_dispWin.x1 = 0;
-	tft_dispWin.y1 = 0;
+	tft_dispWin.x2 = tft_width + TFT_STATIC_X_OFFSET -1;
+	tft_dispWin.y2 = tft_height + TFT_STATIC_Y_OFFSET -1;
+	tft_dispWin.x1 = TFT_STATIC_X_OFFSET;
+	tft_dispWin.y1 = TFT_STATIC_Y_OFFSET;
 }
 
 //==========================================================================

--- a/components/tft/tftspi.c
+++ b/components/tft/tftspi.c
@@ -936,7 +936,7 @@ void TFT_display_init()
 
 	// Clear screen
     _tft_setRotation(PORTRAIT);
-	TFT_pushColorRep(0, 0, tft_width-1, tft_height-1, (color_t){0,0,0}, (uint32_t)(tft_height*tft_width));
+	TFT_pushColorRep(TFT_STATIC_WIDTH_OFFSET, TFT_STATIC_HEIGHT_OFFSET, tft_width + TFT_STATIC_WIDTH_OFFSET -1, tft_height + TFT_STATIC_HEIGHT_OFFSET -1, (color_t){0,0,0}, (uint32_t)(tft_height*tft_width));
 
 	///Enable backlight
 #if PIN_NUM_BCKL

--- a/components/tft/tftspi.h
+++ b/components/tft/tftspi.h
@@ -171,7 +171,7 @@
 #define TFT_INVERT_ROTATION1        1
 #define TFT_RGB_BGR                 0x00
 //To be used by user application for initialization
-#define TFT_ALLWAYS_INVERTED
+#define TFT_START_COLORS_INVERTED
 
 #define USE_TOUCH	TOUCH_TYPE_NONE
 

--- a/components/tft/tftspi.h
+++ b/components/tft/tftspi.h
@@ -157,8 +157,13 @@
 #elif CONFIG_TFT_PREDEFINED_DISPLAY_TYPE == 5
 //CONFIG FOR TTGO T-DISPLAY
 #define DEFAULT_DISP_TYPE           DISP_TYPE_ST7789V
-#define DEFAULT_TFT_DISPLAY_WIDTH   240
-#define DEFAULT_TFT_DISPLAY_HEIGHT  320
+#define DEFAULT_TFT_DISPLAY_WIDTH   135
+#define DEFAULT_TFT_DISPLAY_HEIGHT  240
+
+//Need to be defined together so they can be swapped for x;y when rotating
+#define TFT_STATIC_WIDTH_OFFSET 53
+#define TFT_STATIC_HEIGHT_OFFSET 40
+
 #define DISP_COLOR_BITS_24          0x66
 #define DEFAULT_GAMMA_CURVE         0
 #define DEFAULT_SPI_CLOCK           20000000
@@ -245,6 +250,17 @@
 //----------------------------------------------------------------------------
 
 #endif  // CONFIG_PREDEFINED_DISPLAY_TYPE
+
+// Define offset generation, or ignore offsets if none are needed
+#ifdef TFT_STATIC_WIDTH_OFFSET
+#define TFT_STATIC_X_OFFSET (tft_orientation & 1 ? TFT_STATIC_HEIGHT_OFFSET : TFT_STATIC_WIDTH_OFFSET)
+#define TFT_STATIC_Y_OFFSET (tft_orientation & 1 ? TFT_STATIC_WIDTH_OFFSET : TFT_STATIC_HEIGHT_OFFSET)
+#else
+#define TFT_STATIC_WIDTH_OFFSET 0
+#define TFT_STATIC_X_OFFSET 0
+#define TFT_STATIC_HEIGHT_OFFSET 0
+#define TFT_STATIC_Y_OFFSET 0
+#endif
 
 
 // ##############################################################

--- a/components/tft/tftspi.h
+++ b/components/tft/tftspi.h
@@ -165,6 +165,8 @@
 #define TFT_INVERT_ROTATION         0
 #define TFT_INVERT_ROTATION1        1
 #define TFT_RGB_BGR                 0x00
+//To be used by user application for initialization
+#define TFT_ALLWAYS_INVERTED
 
 #define USE_TOUCH	TOUCH_TYPE_NONE
 

--- a/main/tft_demo.c
+++ b/main/tft_demo.c
@@ -1344,6 +1344,9 @@ void app_main()
 
 	printf("SPI: display init...\r\n");
 	TFT_display_init();
+#ifdef TFT_ALLWAYS_INVERTED
+	TFT_invertDisplay(1);
+#endif
     printf("OK\r\n");
     #if USE_TOUCH == TOUCH_TYPE_STMPE610
 	stmpe610_Init();

--- a/main/tft_demo.c
+++ b/main/tft_demo.c
@@ -1344,7 +1344,7 @@ void app_main()
 
 	printf("SPI: display init...\r\n");
 	TFT_display_init();
-#ifdef TFT_ALLWAYS_INVERTED
+#ifdef TFT_START_COLORS_INVERTED
 	TFT_invertDisplay(1);
 #endif
     printf("OK\r\n");

--- a/main/tft_demo.c
+++ b/main/tft_demo.c
@@ -351,7 +351,7 @@ static void test_times() {
 			tstart = clock();
 			for (int n=0; n<1000; n++) {
 				if (gsline) memcpy(color_line, gsline, tft_width*3);
-				send_data(0, 40+(n&63), tft_dispWin.x2-tft_dispWin.x1, 40+(n&63), (uint32_t)(tft_dispWin.x2-tft_dispWin.x1+1), color_line);
+				send_data(0 + TFT_STATIC_X_OFFSET, 40+(n&63) + TFT_STATIC_Y_OFFSET, tft_dispWin.x2-tft_dispWin.x1 + TFT_STATIC_X_OFFSET , 40+(n&63) + TFT_STATIC_Y_OFFSET, (uint32_t)(tft_dispWin.x2-tft_dispWin.x1+1), color_line);
 				wait_trans_finish(1);
 			}
 			t2 = clock() - tstart;


### PR DESCRIPTION
This eliminates the additional code described here: https://github.com/Xinyuan-LilyGO/TTGO-T-Display/issues/8 , and makes displays with offsets behave much more like normal displays (even when rotating).
Specific code changes in applications only need to be made when using the low level functions from `tftspi.h`, and when initializing the display to check if inversion should be applied from the beginning. (`TFT_ALLWAYS_INVERTED`)

With these patches the TTGO T-Display is now fully supported, and could imho be added to the README.