### PR TITLE
cmake: Declare nvs_flash as a dependency, instead of pushing include path

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,10 +1,9 @@
 set(SOURCES tft_demo.c)
 idf_component_register(
         SRCS ${SOURCES}
-        INCLUDE_DIRS
-          ${CMAKE_CURRENT_LIST_DIR}
-          $ENV{IDF_PATH}/components
         REQUIRES
             tft
             spiffs
+        PRIV_REQUIRES
+            nvs_flash
 )

--- a/main/tft_demo.c
+++ b/main/tft_demo.c
@@ -24,7 +24,7 @@
 #include "freertos/event_groups.h"
 #include "esp_sntp.h"
 #include "esp_log.h"
-#include "nvs_flash/include/nvs_flash.h"
+#include "nvs_flash.h"
 
 #endif
 


### PR DESCRIPTION
For more information about how component requirements are declared, see
https://docs.espressif.com/projects/esp-idf/en/v4.0.1/api-guides/build-system.html#component-requirements

Closes #8