### PR TITLE
Remove recursive include from tftspi.h, add C++ guards to tftspi.h

### DIFF
--- a/components/tft/tft.h
+++ b/components/tft/tft.h
@@ -681,8 +681,8 @@ int compile_font_file(char *fontfile, uint8_t dbg);
  */
 void getFontCharacters(uint8_t *buf);
 
-#endif
-
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* _TFT_H_ */

--- a/components/tft/tftspi.h
+++ b/components/tft/tftspi.h
@@ -7,7 +7,10 @@
 #ifndef _TFTSPI_H_
 #define _TFTSPI_H_
 
-#include "tftspi.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "spi_master_lobo.h"
 #include "sdkconfig.h"
 #include "stmpe610.h"
@@ -781,4 +784,9 @@ uint32_t stmpe610_getID();
 
 // ===============================================================================
 
+
+#ifdef __cplusplus
+}
 #endif
+
+#endif /* _TFTSPI_H_  */


### PR DESCRIPTION
Remove recursive include from tftspi.h and add C++ guards to it.
Correct placement of compiler directives for C++ in tft.h which would have failed if used in C++ and double included.