### PR TITLE
Fixes for compiling with esp-idf v5.0

### DIFF
--- a/components/spidriver/CMakeLists.txt
+++ b/components/spidriver/CMakeLists.txt
@@ -1,2 +1,3 @@
 FILE(GLOB SOURCES *.c)
-idf_component_register(SRCS ${SOURCES} INCLUDE_DIRS ".")
+idf_component_register(SRCS ${SOURCES} INCLUDE_DIRS "."
+                       PRIV_REQUIRES driver)

--- a/components/spidriver/spi_master_lobo.c
+++ b/components/spidriver/spi_master_lobo.c
@@ -68,6 +68,8 @@ Main driver's function is 'spi_lobo_transfer_data()'
 #include "driver/gpio.h"
 #include "spi_master_lobo.h"
 #include "driver/periph_ctrl.h"
+#include "soc/gpio_periph.h"
+#include "rom/gpio.h"
 
 static spi_lobo_host_t *spihost[3] = {NULL};
 

--- a/components/tft/CMakeLists.txt
+++ b/components/tft/CMakeLists.txt
@@ -1,4 +1,5 @@
 FILE(GLOB SOURCES *.c)
 idf_component_register(SRCS ${SOURCES}
                        INCLUDE_DIRS "."
-                       REQUIRES spidriver)
+                       REQUIRES spidriver
+                       PRIV_REQUIRES driver)

--- a/components/tft/tft.c
+++ b/components/tft/tft.c
@@ -2363,7 +2363,7 @@ static UINT tjd_output (
 	}
 	else {
 		wait_trans_finish(1);
-		printf("Data size error: %d jpg: (%d,%d,%d,%d) disp: (%d,%d,%d,%d)\r\n", len, left,top,right,bottom, dleft,dtop,dright,dbottom);
+		printf("Data size error: %lu jpg: (%d,%d,%d,%d) disp: (%d,%d,%d,%d)\r\n", (long unsigned)len, left,top,right,bottom, dleft,dtop,dright,dbottom);
 		return 0;  // stop decompression
 	}
 

--- a/components/tft/tftspi.c
+++ b/components/tft/tftspi.c
@@ -13,6 +13,7 @@
 #include "freertos/task.h"
 #include "soc/spi_reg.h"
 #include "driver/gpio.h"
+#include "rom/gpio.h"
 
 
 // ====================================================
@@ -601,14 +602,14 @@ uint32_t stmpe610_getID()
 void stmpe610_Init()
 {
     stmpe610_write_reg(STMPE610_REG_SYS_CTRL1, 0x02);        // Software chip reset
-    vTaskDelay(10 / portTICK_RATE_MS);
+    vTaskDelay(10 / portTICK_PERIOD_MS);
 
     stmpe610_write_reg(STMPE610_REG_SYS_CTRL2, 0x04);        // Temperature sensor clock off, GPIO clock off, touch clock on, ADC clock on
 
     stmpe610_write_reg(STMPE610_REG_INT_EN, 0x00);           // Don't Interrupt on INT pin
 
     stmpe610_write_reg(STMPE610_REG_ADC_CTRL1, 0x48);        // ADC conversion time = 80 clock ticks, 12-bit ADC, internal voltage refernce
-    vTaskDelay(2 / portTICK_RATE_MS);
+    vTaskDelay(2 / portTICK_PERIOD_MS);
     stmpe610_write_reg(STMPE610_REG_ADC_CTRL2, 0x01);        // ADC speed 3.25MHz
     stmpe610_write_reg(STMPE610_REG_GPIO_AF, 0x00);          // GPIO alternate function - OFF
     stmpe610_write_reg(STMPE610_REG_TSC_CFG, 0xE3);          // Averaging 8, touch detect delay 1ms, panel driver settling time 1ms
@@ -756,7 +757,7 @@ static void commandList(spi_lobo_device_handle_t spi, const uint8_t *addr) {
     if(ms) {
       ms = *addr++;              // Read post-command delay time (ms)
       if(ms == 255) ms = 500;    // If 255, delay for 500 ms
-	  vTaskDelay(ms / portTICK_RATE_MS);
+	  vTaskDelay(ms / portTICK_PERIOD_MS);
     }
   }
 }
@@ -897,9 +898,9 @@ void TFT_display_init()
 #if PIN_NUM_RST
     //Reset the display
     gpio_set_level(PIN_NUM_RST, 0);
-    vTaskDelay(20 / portTICK_RATE_MS);
+    vTaskDelay(20 / portTICK_PERIOD_MS);
     gpio_set_level(PIN_NUM_RST, 1);
-    vTaskDelay(150 / portTICK_RATE_MS);
+    vTaskDelay(150 / portTICK_PERIOD_MS);
 #endif
 
     ret = disp_select();

--- a/main/tft_demo.c
+++ b/main/tft_demo.c
@@ -131,7 +131,7 @@ static int obtain_time(void)
         //ESP_LOGI(tag, "Waiting for system time to be set... (%d/%d)", retry, retry_count);
 		sprintf(tmp_buff, "Wait %0d/%d", retry, retry_count);
     	TFT_print(tmp_buff, CENTER, LASTY);
-		vTaskDelay(500 / portTICK_RATE_MS);
+		vTaskDelay(500 / portTICK_PERIOD_MS);
         time(&time_now);
     	tm_info = localtime(&time_now);
     }
@@ -189,7 +189,7 @@ static int _checkTouch()
 	int tx, ty;
 	if (TFT_read_touch(&tx, &ty, 0)) {
 		while (TFT_read_touch(&tx, &ty, 1)) {
-			vTaskDelay(20 / portTICK_RATE_MS);
+			vTaskDelay(20 / portTICK_PERIOD_MS);
 		}
 		return 1;
 	}
@@ -206,12 +206,12 @@ static int Wait(int ms)
 		ms *= -1;
 	}
 	if (ms <= 50) {
-		vTaskDelay(ms / portTICK_RATE_MS);
+		vTaskDelay(ms / portTICK_PERIOD_MS);
 		//if (_checkTouch()) return 0;
 	}
 	else {
 		for (int n=0; n<ms; n += 50) {
-			vTaskDelay(50 / portTICK_RATE_MS);
+			vTaskDelay(50 / portTICK_PERIOD_MS);
 			if (tm) _checkTime();
 			//if (_checkTouch()) return 0;
 		}
@@ -978,14 +978,14 @@ static void touch_demo()
 				doexit++;
 				if (doexit == 2) update_header(NULL, "---");
 				if (doexit > 50) return;
-				vTaskDelay(100 / portTICK_RATE_MS);
+				vTaskDelay(100 / portTICK_PERIOD_MS);
 			}
 		}
 		else {
 			doexit++;
 			if (doexit == 2) update_header(NULL, "---");
 			if (doexit > 50) return;
-			vTaskDelay(100 / portTICK_RATE_MS);
+			vTaskDelay(100 / portTICK_PERIOD_MS);
 		}
 	}
 #endif
@@ -1294,7 +1294,7 @@ void app_main()
     // ====================================================================================================================
 
 
-    vTaskDelay(500 / portTICK_RATE_MS);
+    vTaskDelay(500 / portTICK_PERIOD_MS);
 	printf("\r\n==============================\r\n");
     printf("TFT display DEMO, LoBo 11/2017\r\n");
 	printf("==============================\r\n");
@@ -1350,7 +1350,7 @@ void app_main()
     printf("OK\r\n");
     #if USE_TOUCH == TOUCH_TYPE_STMPE610
 	stmpe610_Init();
-	vTaskDelay(10 / portTICK_RATE_MS);
+	vTaskDelay(10 / portTICK_PERIOD_MS);
     uint32_t tver = stmpe610_getID();
     printf("STMPE touch initialized, ver: %04x - %02x\r\n", tver >> 8, tver & 0xFF);
     #endif


### PR DESCRIPTION
#### Problem
https://github.com/project-chip/connectedhomeip/tree/master/examples/all-clusters-app/esp32 uses this framework.
When compiling `all-clusters-app/esp32` with esp-idf v5.0 this component fails to build with few errors.

#### Change overview
- Replaced deprecated `portTICK_RATE_MS` with `portTICK_PERIOD_MS`
- With some restructuring of driver component, now we need to explicitly specify driver component in `PRIV_REQUIRES`
- Also, few headers needs to be specified explicitly 

#### Testings
- Verified that `all-clusters-app/esp32` builds with esp-idf v4.4.3 and v5.0
