### PR TITLE
Fix warnings when building with esp-idf v5.2.1

### DIFF
--- a/components/spidriver/spi_master_lobo.c
+++ b/components/spidriver/spi_master_lobo.c
@@ -621,8 +621,8 @@ esp_err_t spi_lobo_bus_remove_device(spi_lobo_device_handle_t handle)
 		if (spihost[handle->host_dev]->device[x] !=NULL) break;
 	}
 	if (x == NO_DEV) {
-		free(handle);
 		spi_lobo_bus_free(handle->host_dev, 1);
+		free(handle);
 	}
 	else free(handle);
 

--- a/components/spiffs/spiffs_vfs.c
+++ b/components/spiffs/spiffs_vfs.c
@@ -47,12 +47,12 @@ int spiffs_is_mounted = 0;
 
 QueueHandle_t spiffs_mutex = NULL;
 
-static int IRAM_ATTR vfs_spiffs_open(const char *path, int flags, int mode);
-static ssize_t IRAM_ATTR vfs_spiffs_write(int fd, const void *data, size_t size);
-static ssize_t IRAM_ATTR vfs_spiffs_read(int fd, void * dst, size_t size);
-static int IRAM_ATTR vfs_spiffs_fstat(int fd, struct stat * st);
-static int IRAM_ATTR vfs_spiffs_close(int fd);
-static off_t IRAM_ATTR vfs_spiffs_lseek(int fd, off_t size, int mode);
+static int vfs_spiffs_open(const char *path, int flags, int mode);
+static ssize_t vfs_spiffs_write(int fd, const void *data, size_t size);
+static ssize_t vfs_spiffs_read(int fd, void * dst, size_t size);
+static int vfs_spiffs_fstat(int fd, struct stat * st);
+static int vfs_spiffs_close(int fd);
+static off_t vfs_spiffs_lseek(int fd, off_t size, int mode);
 
 typedef struct {
 	DIR dir;
@@ -92,7 +92,7 @@ static u8_t *my_spiffs_cache;
 
 //----------------------------------------------------
 void spiffs_fs_stat(uint32_t *total, uint32_t *used) {
-	if (SPIFFS_info(&fs, total, used) != SPIFFS_OK) {
+	if (SPIFFS_info(&fs, (u32_t *)total, (u32_t *)used) != SPIFFS_OK) {
 		*total = 0;
 		*used = 0;
 	}


### PR DESCRIPTION
<details>
  <summary>Warnings</summary>

```
/home/vaishali/esp/connectedhomeip/examples/lighting-app/esp32/third_party/connectedhomeip/examples/common/m5stack-tft/repo/components/spiffs/spiffs_vfs.c: In function 'spiffs_fs_stat':
/home/vaishali/esp/connectedhomeip/examples/lighting-app/esp32/third_party/connectedhomeip/examples/common/m5stack-tft/repo/components/spiffs/spiffs_vfs.c:95:30: warning: passing argument 2 of 'SPIFFS_info' from incompatible pointer type [-Wincompatible-pointer-types]
   95 |         if (SPIFFS_info(&fs, total, used) != SPIFFS_OK) {
      |                              ^~~~~
      |                              |
      |                              uint32_t * {aka long unsigned int *}
In file included from /home/vaishali/esp/connectedhomeip/examples/lighting-app/esp32/third_party/connectedhomeip/examples/common/m5stack-tft/repo/components/spiffs/spiffs_vfs.c:29:
/home/vaishali/esp/connectedhomeip/examples/lighting-app/esp32/third_party/connectedhomeip/examples/common/m5stack-tft/repo/components/spiffs/spiffs.h:607:38: note: expected 'u32_t *' {aka 'unsigned int *'} but argument is of type 'uint32_t *' {aka 'long unsigned int *'}
  607 | s32_t SPIFFS_info(spiffs *fs, u32_t *total, u32_t *used);
      |                               ~~~~~~~^~~~~


/home/vaishali/esp/connectedhomeip/examples/lighting-app/esp32/third_party/connectedhomeip/examples/common/m5stack-tft/repo/components/spiffs/spiffs_vfs.c:174:1: warning: ignoring attribute 'section (".iram1.7")' because it conflicts with previous 'section (".iram1.0")' [-Wattributes]
  174 | static int IRAM_ATTR vfs_spiffs_open(const char *path, int flags, int mode) {
      | ^~~~~~
/home/vaishali/esp/connectedhomeip/examples/lighting-app/esp32/third_party/connectedhomeip/examples/common/m5stack-tft/repo/components/spiffs/spiffs_vfs.c:50:22: note: previous declaration here
   50 | static int IRAM_ATTR vfs_spiffs_open(const char *path, int flags, int mode);
      |                      ^~~~~~~~~~~~~~~
```

</details>

#### Change overview
- typecast for fixing the type
- remove IRAM_ATTR for getting rid of conflic warnings
- fix use after free

#### Tests
Built example - https://github.com/project-chip/connectedhomeip/tree/master/examples/lighting-app/esp32